### PR TITLE
fixed example DeviceContext: Enable All

### DIFF
--- a/WindowsDisplaySample/Program.cs
+++ b/WindowsDisplaySample/Program.cs
@@ -112,8 +112,9 @@ namespace WindowsDisplaySample
                         foreach (var display in displays)
                         {
                             var validSetting = display.GetPreferredSetting();
-                            display.Enable(new DisplaySetting(validSetting, new Point(startPosition, 0)), true);
+                            var placedSettings = new DisplaySetting(validSetting, new Point(startPosition, 0));
                             startPosition += validSetting.Resolution.Width;
+                            display.Enable(placedSettings, true);
                         }
 
                         DisplaySetting.ApplySavedSettings();


### PR DESCRIPTION
in the examples project in the device context examples in the "enable all" part - setting the start position before enabling the display fixed prevented an exception enabling the display