### PR TITLE
fix(finalizer): pass IntPtr instead of SafeHandle in finalizer

### DIFF
--- a/WindowsDisplayAPI/Native/DeviceContext/DCHandle.cs
+++ b/WindowsDisplayAPI/Native/DeviceContext/DCHandle.cs
@@ -49,8 +49,8 @@ namespace WindowsDisplayAPI.Native.DeviceContext
         protected override bool ReleaseHandle()
         {
             return _created
-                ? DeviceContextApi.DeleteDC(this)
-                : DeviceContextApi.ReleaseDC(IntPtr.Zero, this);
+                ? DeviceContextApi.DeleteDC(this.handle)
+                : DeviceContextApi.ReleaseDC(IntPtr.Zero, this.handle);
         }
     }
 }

--- a/WindowsDisplayAPI/Native/DeviceContextApi.cs
+++ b/WindowsDisplayAPI/Native/DeviceContextApi.cs
@@ -37,7 +37,7 @@ namespace WindowsDisplayAPI.Native
         internal static extern IntPtr CreateDC(string driver, string device, string port, IntPtr deviceMode);
 
         [DllImport("gdi32")]
-        internal static extern bool DeleteDC(DCHandle dcHandle);
+        internal static extern bool DeleteDC(IntPtr dcHandle);
 
 
         [DllImport("user32", CharSet = CharSet.Unicode)]
@@ -90,7 +90,7 @@ namespace WindowsDisplayAPI.Native
         );
 
         [DllImport("user32")]
-        internal static extern bool ReleaseDC([In] IntPtr windowHandle, [In] DCHandle dcHandle);
+        internal static extern bool ReleaseDC([In] IntPtr windowHandle, [In] IntPtr dcHandle);
 
         [DllImport("gdi32")]
         internal static extern bool SetDeviceGammaRamp(DCHandle dcHandle, ref GammaRamp ramp);


### PR DESCRIPTION
This fixes usage of SafeHandle that is being disposed/was disposed in the finalizer to call external function. Passing the SafeHandle wrapped object fails as it is disposed already and `SafeHandleAddRef` throws an exception while performing interop.

See similar SO issue:  https://stackoverflow.com/a/47940095

I have been running a program with this fix and have not it crash for over a day, where as previously it would fail after an hour or two. 